### PR TITLE
adding support for using `importModule` inside `importString`

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -67,6 +67,7 @@ const esbuild: typeof webAssemblyEsbuild = isDenoCLI
 	? nativeEsbuild
 	: webAssemblyEsbuild
 
+
 const sharedEsbuildOptions:
 	webAssemblyEsbuild.BuildOptions = {
 		jsx: {
@@ -120,6 +121,7 @@ async function getDenoConfiguration() {
 async function buildAndEvaluate(
 	options: webAssemblyEsbuild.BuildOptions,
 	url: URL,
+	modules: Record<string, unknown> = {}, 
 ) {
 	if (!isDenoCLI) {
 		esbuild.initialize({
@@ -147,7 +149,7 @@ async function buildAndEvaluate(
 			'$<exported>: $<local>',
 		)
 
-	const exports = await AsyncFunction(body)()
+	const exports = await AsyncFunction('modules',body)(modules)
 
 	const prototypedAndToStringTaggedExports = Object.assign(
 		Object.create(null),
@@ -214,7 +216,8 @@ export async function importString<
 		base = new URL(
 			ErrorStackParser.parse(new Error())[1].fileName,
 		),
-	}: ImportStringOptions = {},
+		modules={},
+	}: ImportStringOptions & { modules?: Record<string, unknown> }= {},
 ) {
 	return (await buildAndEvaluate(
 		{
@@ -225,5 +228,6 @@ export async function importString<
 			},
 		},
 		base,
+		modules
 	)) as Module
 }

--- a/mod.ts
+++ b/mod.ts
@@ -67,6 +67,9 @@ const esbuild: typeof webAssemblyEsbuild = isDenoCLI
 	? nativeEsbuild
 	: webAssemblyEsbuild
 
+let checkInitialization: boolean = false;
+
+
 const sharedEsbuildOptions:
 	webAssemblyEsbuild.BuildOptions = {
 		jsx: {
@@ -121,10 +124,11 @@ async function buildAndEvaluate(
 	options: webAssemblyEsbuild.BuildOptions,
 	url: URL,
 ) {
-	if (!isDenoCLI) {
+	if (!isDenoCLI && !checkInitialization) {
 		esbuild.initialize({
 			worker: typeof Worker !== 'undefined',
 		})
+		checkInitialization=true;
 	}
 
 	const buildResult = await esbuild.build(

--- a/test.ts
+++ b/test.ts
@@ -1,18 +1,39 @@
-import { importModule, importString } from "./mod.ts";
+import { importModule, importString } from './mod.ts'
 
-Deno.test("`importModule`", async () => {
-  console.log(await importModule("test", { force: true }));
+Deno.test('`importModule`', async () => {
+	console.log(await importModule('test', { force: true }))
 
-  console.log(
-    await importModule(
-      "https://api.observablehq.com/d/6388e91a5ea79803.js?v=3",
-      {
-        force: true,
-      },
-    ),
-  );
-});
+	console.log(
+		await importModule(
+			'https://api.observablehq.com/d/6388e91a5ea79803.js?v=3',
+			{
+				force: true,
+			},
+		),
+	)
+})
 
 Deno.test("importString", async () => {
   console.log(await importString('export const foo = "bar"'));
 });
+
+Deno.test('importStringWithModules', async () => {
+	let { default: renderer } = await importString(`
+    const renderer = async ()=>{
+
+      const { render } = await modules.importModule('https://deno.land/x/mustache_ts/mustache.ts');
+
+      const template = '{{foo}}, {{bar}}!'
+      const view = {
+          foo: 'Hello',
+          bar: 'World!'
+      }
+      const output = render(template, view)
+      return output;
+    };
+    export default renderer;
+  `,
+		{ modules: { importModule } },
+	)
+  console.log(await renderer())
+})


### PR DESCRIPTION
Adding support for using `importModule` inside `importString`, and also other dependencies.

Example:
```js
let { default: renderer } = await importString(`
    const renderer = async ()=>{

      const { render } = await modules.importModule('https://deno.land/x/mustache_ts/mustache.ts');

      const template = '{{foo}}, {{bar}}!'
      const view = {
          foo: 'Hello',
          bar: 'World!'
      }
      const output = render(template, view)
      return output;
    };
    export default renderer;
  `,
    { modules: { importModule } },
)
  console.log(await renderer()) // expected: "Hello, World!"
  
```