### PR TITLE
getCallerUrl fallback to avoid invalid URL error

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -108,10 +108,10 @@ const esbuildOptions: webAssemblyEsbuild.BuildOptions = {
 	}),
 };
 
-const AsyncFunction = async function () {}.constructor;
+const AsyncFunction = async function() { }.constructor;
 
 function customPrepareStackTrace(_error: Error, callSites: CallSite[]) {
-	return callSites.at(2)!.getFileName();
+	return callSites[2] && callSites[2].getFileName();
 }
 
 function getCallerUrl() {
@@ -120,12 +120,16 @@ function getCallerUrl() {
 	Error.stackTraceLimit = Infinity;
 	Error.prepareStackTrace = customPrepareStackTrace;
 
-	const callerUrl = new URL(new Error().stack!);
+	const callerFile = new Error().stack;
 
 	Error.stackTraceLimit = stackTraceLimit;
 	Error.prepareStackTrace = prepareStackTrace;
 
-	return callerUrl;
+	if (callerFile) {
+		return new URL(callerFile);
+	} else {
+		return new URL(import.meta.url);
+	}
 }
 
 async function buildAndEvaluate(


### PR DESCRIPTION
I have encountered following error while running example from unit as compiled executable

```
error: Uncaught (in promise) TypeError: Invalid URL: 'undefined'
    at <anonymous> (ext:deno_url/00_url.js:89:11)
```

To reproduce, create sep28.ts

```
import { dynamicImport, importString } from './mod.ts';

const { default: renderer } = await importString(
	`export default async function () {
	const { render } = await dynamicImport('https://deno.land/x/mustache_ts@v0.4.1.1/mustache.ts');

	const template = '{{foo}}, {{bar}}!'
	const view = {
		foo: 'Hello',
		bar: 'World!'
	}
	const output = render(template, view)

	return output;
};`,
	{ parameters: { dynamicImport } },
);

console.log(await renderer());
```

Then compile

```
deno compile --allow-all --unstable --no-check sep28.ts
```