### PR TITLE
bypassing path resolver error with wasmEsbuild

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -90,7 +90,7 @@ let esbuildInitialized = false;
 const esbuildOptions: webAssemblyEsbuild.BuildOptions = {
 	bundle: true,
 	platform: 'neutral',
-	tsconfig: configurationPath ?? undefined,
+	tsconfigRaw: configuration ?? undefined,
 	format: 'esm',
 	write: false,
 	ignoreAnnotations: true,


### PR DESCRIPTION
hi. when `!isDenoCLI`, tsconfig fails to resolve to the `deno.json` file. this change bypasses it